### PR TITLE
Fix bug that causes building for ios-appstore to fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 .DS_Store
 Thumbs.db
+
+package-metadata.json

--- a/Titanium.py
+++ b/Titanium.py
@@ -331,7 +331,7 @@ class TitaniumCommand(sublime_plugin.WindowCommand):
             options.extend(["--developer-name", "\"" + self.cert[0] + "\""])
             options.extend(["--device-id", self.deviceudid])
         else:
-            options.extend(["--distribution-name", "\"" + self.cert + "\""])
+            options.extend(["--distribution-name", "\"" + self.cert[0] + "\""])
 
         if self.target == "dist-adhoc":
             options.extend(["--output-dir", self.project_folder + "/dist"])


### PR DESCRIPTION
When building for the ios app store, the following error is thrown:

```
Traceback (most recent call last):
  File "./Titanium.py", line 334, in select_ios_profile
    options.extend(["--distribution-name", "\"" + self.cert + "\""])
TypeError: cannot concatenate 'str' and 'list' objects
```

the error occurs because self.cert is not a string, but a string array with 1 item. This commit fixes the problem by using `self.cert[0]`, which is the same value that's used three lines above when building for a device. 
