### PR TITLE
Android Play store build options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 .DS_Store
 Thumbs.db
+
+package-metadata.json

--- a/Titanium.sublime-settings
+++ b/Titanium.sublime-settings
@@ -5,6 +5,8 @@
 	"loggingLevel": "info",
 	// Path to the android sdk
 	"androidSDK": "~/Library/android-sdk-macosx",
+	// Path to your Google Play Services keystore file.
+	"androidKeystore": "",
 	// Extra Settings for the iOS Simulator
 	// If you dont want to set them, make the values false
 	// simulatorType - This will override the selection popup, value can be "iphone", "ipad" or false


### PR DESCRIPTION
This commit adds the ability to specify several pieces of information used for building an app for the Google Play app store. 
First, it adds a setting to the preferences file to allow the user to set the location of their android keystore file. This setting defaults to an empty string. During build, if the string is empty, then the user will be prompted to enter the path to the keystore file. This should allow a flexible setup to support both users that have a single keystore file (they can set the setting in their preferences and not have to enter it for every build) and users that have multiple keystores (they leave the setting empty and enter the path for each build). 
During build, it will prompt the user to enter their keystore password (I could not find a good way to hide the password. So unfortunately, it's typed in the input box in plain text). 
Next, the user is prompted to enter the Key Alias for the app. 
All three of these pieces of information are necessary when building for the Google Play appstore.

Finally, when building for the google play app store, the output-dir is set to a subfolder under the project, `dist/<project version>` where <project version> is the version string set in the tiapp.xml. I also updated the ios dist-adhoc build target to use this same folder for it's output-dir for consistency. 
